### PR TITLE
Adiciona função shoot() no _process para debug

### DIFF
--- a/Assets/Art/3D/Weapons/Shotgun/Shotgun.tscn
+++ b/Assets/Art/3D/Weapons/Shotgun/Shotgun.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=6 format=3 uid="uid://bfem73oqilm54"]
+
+[ext_resource type="PackedScene" uid="uid://bs1456xr0xd0t" path="res://Assets/Art/3D/12.glb" id="1_pu07x"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_kw0u0"]
+albedo_color = Color(0.152941, 0.152941, 0.152941, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_gu1bf"]
+albedo_color = Color(0.137255, 0.137255, 0.137255, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_qi5ek"]
+cull_mode = 2
+albedo_color = Color(1, 1, 1, 0.976471)
+emission_enabled = true
+emission = Color(1, 1, 1, 1)
+emission_energy_multiplier = 0.33
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_nht5b"]
+albedo_color = Color(0.121569, 0.121569, 0.121569, 1)
+
+[node name="Shotgun" instance=ExtResource("1_pu07x")]
+transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 0, 0)
+
+[node name="Cube" parent="." index="1"]
+material_override = SubResource("StandardMaterial3D_kw0u0")
+
+[node name="Cylinder002" parent="." index="2"]
+material_override = SubResource("StandardMaterial3D_gu1bf")
+
+[node name="Cylinder" parent="." index="4"]
+material_override = SubResource("StandardMaterial3D_qi5ek")
+
+[node name="Cylinder004" parent="." index="5"]
+material_override = SubResource("StandardMaterial3D_nht5b")

--- a/Scenes/Weapons/Pistol/Pistol.tscn
+++ b/Scenes/Weapons/Pistol/Pistol.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://corqtxk48svlc"]
 
 [ext_resource type="Script" path="res://Scripts/Weapons/Pistol/Pistol.gd" id="1_ia61s"]
-[ext_resource type="PackedScene" uid="uid://bs1456xr0xd0t" path="res://Assets/Art/3D/12.glb" id="2_kq10u"]
+[ext_resource type="PackedScene" uid="uid://bfem73oqilm54" path="res://Assets/Art/3D/Weapons/Shotgun/Shotgun.tscn" id="2_8uue6"]
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_xb5it"]
 
@@ -19,11 +19,10 @@ collision_mask = 8
 shape = SubResource("CylinderShape3D_xb5it")
 
 [node name="Camera3D" type="Camera3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, -0.114819, 12.6475, -0.0373204)
+transform = Transform3D(0.0321831, -0.695076, 0.718216, 0.164786, 0.712445, 0.682106, -0.985804, 0.0963997, 0.137467, 1.98326, 3.17136, -0.289063)
 
 [node name="Node3D" type="Node3D" parent="."]
 
-[node name="12" parent="Node3D" instance=ExtResource("2_kq10u")]
-transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 0, 0)
+[node name="Shotgun" parent="Node3D" instance=ExtResource("2_8uue6")]
 
 [connection signal="body_exited" from="ShotRange" to="." method="_on_shot_range_body_exited"]

--- a/Scripts/Weapons/Pistol/Pistol.gd
+++ b/Scripts/Weapons/Pistol/Pistol.gd
@@ -6,6 +6,11 @@ const HANDLER_NAME = ""
 @export var shot_range = 8.0
 @export var ammo_amount = 6
 
+func _process(delta):
+	# For debug pourpose only
+	if Input.is_action_just_pressed("shoot"):
+		shoot(ammo_type["lead"])
+
 func _ready():
 	$ShotRange/ShotRangeArea.shape.radius = shot_range
 


### PR DESCRIPTION
Para debug, coloquei uma captura de input do botão esquerdo do mouse para atirar com a arma.
Também modifiquei o modelo 3d da arma, fazendo uma gambiarra com o Albedo para poder enxergar. Aparentemente, a cor branca é tira como transparente para o modelo.